### PR TITLE
Changes authentication logic and handle dll crashing

### DIFF
--- a/LocalDB/LocalDB/helper.cpp
+++ b/LocalDB/LocalDB/helper.cpp
@@ -44,9 +44,10 @@ void HandleBadReponse (CAStrPtr pBadResponseSource, StrPtr& pBadRespDestination)
 {
         ULong len;
 
-    if (*pBadRespDestination || pBadRespDestination) {
+    if (pBadRespDestination != nullptr && *pBadRespDestination) {
 
         free (pBadRespDestination);
+        pBadRespDestination = nullptr;
 
     }
 

--- a/LocalDB/LocalDB/sqlserver.cpp
+++ b/LocalDB/LocalDB/sqlserver.cpp
@@ -422,12 +422,12 @@ eGoodBad TSqlServer::ConnectSqlServer (AStrPtr pServer, AStrPtr pUserName, AStrP
         return BAD;
     }
 
-    if (*pUserName && *pPassword) {
+    if ((pUserName && *pUserName) || (pPassword && *pPassword)) {
 
-        conn_str_len = (ULong) (strlen (SQL_SQL_SERVER_AUTHENTICATION) + strlen (pServer) + strlen (pUserName) + strlen (pPassword) + 1);
+        conn_str_len = (ULong) (strlen (SQL_SQL_SERVER_AUTHENTICATION) + strlen (pServer) + strlen (pUserName ? pUserName : "") + strlen (pPassword ? pPassword : "") + 1);
         conn_str     = (AStrPtr) malloc ((conn_str_len + 1) * sizeof (AChar));
 
-        sprintf (conn_str, SQL_SQL_SERVER_AUTHENTICATION, pServer, pUserName, pPassword);
+        sprintf (conn_str, SQL_SQL_SERVER_AUTHENTICATION, pServer, pUserName ? pUserName : "", pPassword ? pPassword : "");
 
     } else {
 


### PR DESCRIPTION
- If username and password is not there then it will use windows authentication

- If username and password is there then it will use sql server authentication
- If username or password is there then it will use sql server authentication
- Handle crashing dll